### PR TITLE
use zsh globbing instead of subshell pipeline

### DIFF
--- a/init.zsh
+++ b/init.zsh
@@ -11,11 +11,11 @@ _prompt_mnml_buffer-empty() {
     if (( MNML_LAST_ERR )) print -Pn '%F{${MNML_ERR_COLOR}}${MNML_LAST_ERR} '
     print -Pn '%(1j.%F{244}%j%f& .)%F{244}%n%f@%F{244}%m%f:'
     print -Pn %F{244}${${(%):-%~}//\//%f\/%F{244}}
-    local -i a_files=$(command ls -Aq | command wc -l)
-    local -i v_files=$(command ls -q | command wc -l)
-    local -i h_files=$(( a_files - v_files ))
-    print -Pn " %f[%F{244}${v_files}%f"
-    if (( h_files )) print -Pn " (%F{244}${h_files}%f)"
+    local -a a_files=(*(DN))
+    local -a v_files=(*(N^D))
+    local -a h_files=(${a_files:|v_files})
+    print -Pn " %f[%F{244}${#v_files}%f"
+    if (( #h_files )) print -Pn " (%F{244}${#h_files}%f)"
     print ]
     # display magic enter
     if (( ${#dirstack} )) print -P %F{244}${${dirstack/${HOME}/\~}//\//%f\/%F{244}}%f


### PR DESCRIPTION
Instead of running `ls` and `wc` in a subshell, use zsh globbing to count the files.

Not sure of the actual performance impact of this, but it ✨feels✨ more robust